### PR TITLE
Allow the use of DNS CNAME to verify ownership of domain.

### DIFF
--- a/src/helpers/CommonHelper.php
+++ b/src/helpers/CommonHelper.php
@@ -107,7 +107,7 @@ class CommonHelper
         {
             foreach ($recordList as $record)
             {
-                if ($record['host'] == $host && $record['type'] == 'TXT' && $record['txt'] == $dnsContent)
+                if ($record['type'] == 'TXT' && $record['txt'] == $dnsContent)
                 {
                     return TRUE;
                 }


### PR DESCRIPTION
To allow the usage of a CNAME for DNS challenges.

Let's Encrypt follows a CNAME as documented @ https://letsencrypt.org/docs/caa/