### PR TITLE
Replace infinite wait with timeouts

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -85,7 +85,7 @@ foreach ($challengeList as $challenge)
 {
     $challenge->getType();          // Challenge type, http-01 or dns-01
     $challenge->getCredential();    // Challenge detail, http-01 with file name and file content, dns-01 with dns record value
-    $challenge->verify();           // Do verifying operation, this method will loop infinitely until verification passed
+    $challenge->verify();           // Do verifying operation, this method will timeout after 180 seconds by default
 }
 ```
 

--- a/src/services/ChallengeService.php
+++ b/src/services/ChallengeService.php
@@ -76,13 +76,14 @@ class ChallengeService
 
     /**
      * Verify
+     * @param int $timeout
      * @return bool
      * @throws \stonemax\acme2\exceptions\AccountException
      * @throws \stonemax\acme2\exceptions\AuthorizationException
      * @throws \stonemax\acme2\exceptions\NonceException
      * @throws \stonemax\acme2\exceptions\RequestException
      */
-    public function verify()
+    public function verify($timeout = 180)
     {
         $orderService = Client::$runtime->order;
 
@@ -91,6 +92,6 @@ class ChallengeService
             return TRUE;
         }
 
-        return $this->_authorication->verify($this->_type);
+        return $this->_authorication->verify($this->_type, $timeout);
     }
 }


### PR DESCRIPTION
We have seen the verification stuck forever in our testing in the case where an `_acme-challenge` CNAME record was incorrect, so a timeout would be good to understand what may have happened.

I checked the acmephp project and they have a similar timeout of 180 seconds on let's encrypt operations, so I think a default of 180 seconds would be sufficient.
e.g. https://github.com/acmephp/acmephp/blob/d4dcd9f0093cba07b140cafd631347e4c0a18e69/src/Core/AcmeClient.php#L178