### PR TITLE
Add optional key length to OpenSSLHelper

### DIFF
--- a/src/helpers/OpenSSLHelper.php
+++ b/src/helpers/OpenSSLHelper.php
@@ -99,7 +99,7 @@ class OpenSSLHelper
      * @param string $privateKey
      * @return mixed
      */
-    public static function generateCSR($domainList, $dn, $privateKey)
+    public static function generateCSR($domainList, $dn, $privateKey, $bits = 4096)
     {
         $san = array_map(
             function($domain) {
@@ -116,7 +116,7 @@ class OpenSSLHelper
             HOME = .
             RANDFILE = \$ENV::HOME/.rnd
             [ req ]
-            default_bits = 4096
+            default_bits = ".$bits."
             default_keyfile = privkey.pem
             distinguished_name = req_distinguished_name
             req_extensions = v3_req


### PR DESCRIPTION
Added a $bits argument to OpenSSLHelper::generateCSR(). Mainly because I'd love to use this package to create certificates that can be used in Amazon CloudFront, but for some reason, certificates uploaded into the AWS Certificate Manager must have a key length of 2048 bits in order to work with CloudFront.