### PR TITLE
HEAD to new-nonce returns HTTP status 200, not 204

### DIFF
--- a/src/services/NonceService.php
+++ b/src/services/NonceService.php
@@ -84,7 +84,7 @@ class NonceService
 
         list($code, $header, ) = RequestHelper::head($newNonceUrl);
 
-        if ($code != 204)
+        if ($code != 200)
         {
             throw new NonceException("Get new nonce failed, the url is: {$newNonceUrl}");
         }


### PR DESCRIPTION
https://tools.ietf.org/html/draft-ietf-acme-acme-18#section-7.2
https://community.letsencrypt.org/t/acme-v2-change-to-http-status-code-for-head-new-nonce/82000

Reported regarding acme2 at https://community.letsencrypt.org/t/no-204-code-on-nonce-check/83959